### PR TITLE
Update heatmap.py solving a csv reading problem.

### DIFF
--- a/heatmap.py
+++ b/heatmap.py
@@ -788,7 +788,8 @@ def shapes_from_csv(filename, ignore_csv_header):
     import csv
     logging.info('reading csv')
     count = 0
-    with open(filename, 'ru') as f:
+    # Using 'rU' instead of 'ru' in open function for all python versions.
+    with open(filename, 'rU') as f:
         reader = csv.reader(f)
         if ignore_csv_header:
             next(reader)  # Skip header line


### PR DESCRIPTION
If you export data from excel in Mac OS X to csv file, python shows the error: <code>new-line character seen in unquoted field - do you need to open the file in universal-newline mode?</code>
This issue was solved changing 'ru' by 'rU' at line 793, in open function - I have no idea why!
