### PR TITLE
Use a UTC time function

### DIFF
--- a/heatmap.py
+++ b/heatmap.py
@@ -28,7 +28,8 @@ import tempfile
 import os.path
 import shutil
 import subprocess
-from time import mktime, strptime
+from time import strptime
+from calendar import timegm
 from collections import defaultdict
 import xml.etree.cElementTree as ET
 from colorsys import hsv_to_rgb
@@ -113,7 +114,7 @@ class TrackLog:
                 timestr = elem.findtext('time')
                 if timestr:
                     timestr = timestr[:-1].split('.')[0] + ' GMT'
-                    point.time = mktime(
+                    point.time = timegm(
                         strptime(timestr, '%Y-%m-%dT%H:%M:%S %Z'))
                 elem.clear()  # clear the trkpt node to minimize memory usage
 


### PR DESCRIPTION
I have a GPX which for some reason has timestamps set to Unix time 0. It's causing `OverflowError: mktime argument out of range`.

---

We have a GMT/UTC timestamp.

 * `timegm` expects UTC.
 * `mktime` expects localtime.

Giving a UTC timestamp  to `mktime` can cause OverflowError in edge cases.

For example when in UTC+2 time zones, these cause `OverflowError: mktime argument out of range` with mktime:
 * "1970-01-01T00:00:00 GMT"
 * "1970-01-01T01:59:59 GMT"

And this returns 0.0:
"1970-01-01T02:00:00 GMT"

But with `timegm` those return 0, 7199 and 7200.