### PR TITLE
Coverage 4.0 doesn't support Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ before_install:
 
 install:
     - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
+    # Coverage 4.0 doesn't support Python 3.2
+    - if [ "${TRAVIS_PYTHON_VERSION:0:3}" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+    - if [ "${TRAVIS_PYTHON_VERSION:0:3}" != "3.2" ]; then travis_retry pip install coverage; fi
     - travis_retry pip install coveralls
     - travis_retry pip install --quiet git+https://github.com/python-imaging/Pillow.git
     - travis_retry sudo apt-get --quiet=2 install perceptualdiff


### PR DESCRIPTION
So for Python 3.2, use the last version that supported it.