### PR TITLE
Don't cover main()

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,4 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+    def main():


### PR DESCRIPTION
`if __name__ == .__main__.:` is already skipped.