### PR TITLE
Update Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
     - if [ "${TRAVIS_PYTHON_VERSION:0:3}" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
     - if [ "${TRAVIS_PYTHON_VERSION:0:3}" != "3.2" ]; then travis_retry pip install coverage; fi
     - travis_retry pip install coveralls
-    - travis_retry pip install --quiet git+https://github.com/python-imaging/Pillow.git
+    - travis_retry pip install pillow
     - travis_retry sudo apt-get --quiet=2 install perceptualdiff
 
     # we only have gdal in system packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ language: python
 python:
     - "pypy"
     - "pypy3"
-    - "2.6"
     - "2.7"
     - "2.7_with_system_site_packages"
-    - "3.2"
-    - "3.2_with_system_site_packages"
-    - "3.3"
-    - "3.4"
+    - "3.6"
     - "3.5"
+    - "3.4"
+    - "3.3"
+    - "3.2_with_system_site_packages"
+    - "3.2"
+    - "2.6"
 
 before_install:
     - sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.7/lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,11 @@ python:
     - "3.3"
     - "3.2_with_system_site_packages"
     - "3.2"
-    - "2.6"
 
 before_install:
     - sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.7/lib/
 
 install:
-    - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then travis_retry pip install unittest2; fi
     # Coverage 4.0 doesn't support Python 3.2
     - if [ "${TRAVIS_PYTHON_VERSION:0:3}" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
     - if [ "${TRAVIS_PYTHON_VERSION:0:3}" != "3.2" ]; then travis_retry pip install coverage; fi

--- a/test/helper.py
+++ b/test/helper.py
@@ -7,11 +7,7 @@ import imp
 import os
 import subprocess
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test.py
+++ b/test/test.py
@@ -3,11 +3,7 @@
 
 import os
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test_animation.py
+++ b/test/test_animation.py
@@ -4,11 +4,7 @@
 import os
 import subprocess
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -3,11 +3,7 @@
 
 import os
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test_coordinates.py
+++ b/test/test_coordinates.py
@@ -3,11 +3,7 @@
 
 import os
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test_gradients.py
+++ b/test/test_gradients.py
@@ -4,11 +4,7 @@
 import os
 import subprocess
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test_projection_scale.py
+++ b/test/test_projection_scale.py
@@ -4,11 +4,7 @@
 import os
 import subprocess
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test_projections.py
+++ b/test/test_projections.py
@@ -3,11 +3,7 @@
 
 import os
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -4,11 +4,7 @@
 import os
 import subprocess
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)

--- a/test/test_shp_file.py
+++ b/test/test_shp_file.py
@@ -4,11 +4,7 @@
 import os
 import subprocess
 import sys
-
-try:
-    import unittest2 as unittest  # Python 2.6
-except ImportError:
-    import unittest
+import unittest
 
 ROOT_DIR = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
 sys.path.append(ROOT_DIR)


### PR DESCRIPTION
* Python 3.6 is out
* Python 2.6 is no longer supported as CPython or by Pillow and other libraries
* Build older Python 3.x versions last
* Install Pillow from PyPI, to use prebuilt binary wheels where available, rather than building from source. Speeds up builds by about a minute.