### PR TITLE
Travis CI: use 3.4_with_system_site_packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
     - "3.6"
     - "3.5"
     - "3.4"
+    - "3.4_with_system_site_packages"
     - "3.3"
-    - "3.2_with_system_site_packages"
     - "3.2"
 
 before_install:


### PR DESCRIPTION
Instead of 3.2_with_system_site_packages which is no longer supported on Trusty.

See: https://github.com/travis-ci/travis-ci/issues/4260#issuecomment-120405756

Before: https://travis-ci.org/hugovk/heatmap/builds/274320824
After: https://travis-ci.org/hugovk/heatmap/builds/274333056
