### PR TITLE
Temporarily use old coverage==4.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
     # Coverage 4.0 doesn't support Python 3.2
     - if [ "${TRAVIS_PYTHON_VERSION:0:3}" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
-    - if [ "${TRAVIS_PYTHON_VERSION:0:3}" != "3.2" ]; then travis_retry pip install coverage; fi
+    - if [ "${TRAVIS_PYTHON_VERSION:0:3}" != "3.2" ]; then travis_retry pip install coverage==4.0.3; fi
     - travis_retry pip install coveralls
     - travis_retry pip install pillow
     - travis_retry sudo apt-get --quiet=2 install perceptualdiff


### PR DESCRIPTION
Something has changed in the way latest coverage==4.3.4 collects works.

For example, test_system.py is now collecting no coverage: 
* March 2016 https://travis-ci.org/hugovk/heatmap/jobs/117235776#L271 
* April 2017: https://travis-ci.org/hugovk/heatmap/jobs/225354088#L266

For the short term, let's use the old version, and then make changes to use the latest coverage properly.

This increases coverage recorded from 49.79% to 78.36%.
https://coveralls.io/builds/13223416
https://coveralls.io/builds/13228250

See also https://github.com/sethoscope/heatmap/issues/41.