### PR TITLE
Update coverage command call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
     # Coverage 4.0 doesn't support Python 3.2
     - if [ "${TRAVIS_PYTHON_VERSION:0:3}" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
-    - if [ "${TRAVIS_PYTHON_VERSION:0:3}" != "3.2" ]; then travis_retry pip install coverage==4.0.3; fi
+    - if [ "${TRAVIS_PYTHON_VERSION:0:3}" != "3.2" ]; then travis_retry pip install coverage; fi
     - travis_retry pip install coveralls
     - travis_retry pip install pillow
     - travis_retry sudo apt-get --quiet=2 install perceptualdiff

--- a/test/helper.py
+++ b/test/helper.py
@@ -15,7 +15,7 @@ sys.path.append(ROOT_DIR)
 try:
     imp.find_module("coverage")
     # TODO COVERAGE_ARGS or something
-    COVERAGE_CMD = ["coverage", "run", "--append", "--source", "heatmap.py"]
+    COVERAGE_CMD = ["coverage", "run", "--append", "--include=heatmap.py"]
 except ImportError:
     COVERAGE_CMD = []
 


### PR DESCRIPTION
The parameters changed between coverage 4.0.3 and 4.3.4 which caused how we use it to not collect the same coverage.

Update how it's called so we can use the latest version.

See #41.