### PR TITLE
Drop support for EOL Python 3.2 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
     - pip install coverage
     - travis_retry pip install coveralls
-    - travis_retry pip install pillow
+    - travis_retry pip install -r requirements.txt
     - travis_retry sudo apt-get --quiet=2 install perceptualdiff
 
     # we only have gdal in system packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,18 @@ python:
     - "3.5"
     - "3.4"
     - "3.4_with_system_site_packages"
-    - "3.3"
-    - "3.2"
 
 before_install:
     - sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.7/lib/
 
 install:
-    # Coverage 4.0 doesn't support Python 3.2
-    - if [ "${TRAVIS_PYTHON_VERSION:0:3}" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
-    - if [ "${TRAVIS_PYTHON_VERSION:0:3}" != "3.2" ]; then travis_retry pip install coverage; fi
+    - pip install coverage
     - travis_retry pip install coveralls
     - travis_retry pip install pillow
     - travis_retry sudo apt-get --quiet=2 install perceptualdiff
 
     # we only have gdal in system packages
-    - if [ "$TRAVIS_PYTHON_VERSION" == "2.7_with_system_site_packages" -o "$TRAVIS_PYTHON_VERSION" == "3.2_with_system_site_packages" ]; then pushd depends && ./install_gdal.sh && popd; fi
+    - if [ "$TRAVIS_PYTHON_VERSION" == "2.7_with_system_site_packages" ]; then pushd depends && ./install_gdal.sh && popd; fi
 
 script:
     - coverage erase
@@ -43,10 +39,10 @@ script:
     - python test/test_system_csv.py
 
     # we only have gdal in system packages
-    - if [ "$TRAVIS_PYTHON_VERSION" == "2.7_with_system_site_packages" -o "$TRAVIS_PYTHON_VERSION" == "3.2_with_system_site_packages" ]; then coverage run --source heatmap --append ./test/test_shp_file.py; fi
+    - if [ "$TRAVIS_PYTHON_VERSION" == "2.7_with_system_site_packages" ]; then coverage run --source heatmap --append ./test/test_shp_file.py; fi
 
     # we only have gdal in system packages
-    - if [ "$TRAVIS_PYTHON_VERSION" == "2.7_with_system_site_packages" -o "$TRAVIS_PYTHON_VERSION" == "3.2_with_system_site_packages" ]; then python test/test_old_cmdline_support.py; fi
+    - if [ "$TRAVIS_PYTHON_VERSION" == "2.7_with_system_site_packages" ]; then python test/test_old_cmdline_support.py; fi
 
 after_success:
     - coverage report


### PR DESCRIPTION
Also explicitly install from requirements.txt on Travis CI, this makes sure the file is in a good state.