### PR TITLE
Avoid ZeroDivisionError and IndexError; Fixes #51

### DIFF
--- a/heatmap.py
+++ b/heatmap.py
@@ -575,7 +575,10 @@ class ColorMap:
                 self.values.append(rgba)
 
     def get(self, floatval):
-        return self.values[int(floatval * (len(self.values) - 1))]
+        try:
+            return self.values[int(floatval * (len(self.values) - 1))]
+        except IndexError:
+            return self.values[0 if floatval<0 else -1]
 
 
 class ImageMaker():
@@ -624,7 +627,7 @@ class ImageMaker():
             x = int(coord.x - extent.min.x)
             y = int(coord.y - extent.min.y)
             if extent.is_inside(coord):
-                color = self.config.colormap.get(val / maxval)
+                color = self.config.colormap.get(val / maxval) if maxval > 0 else self.config.colormap.get(0)
                 if self.background:
                     pixels[x, y] = ImageMaker._blend_pixels(color,
                                                             self.background)

--- a/heatmap.py
+++ b/heatmap.py
@@ -846,8 +846,9 @@ class CSVFileReader(FileReader):
         count = 0
         for row in reader:
             (lat, lon) = (float(row[0]), float(row[1]))
+            weight = float(row[2]) if len(row) > 2 else 1.0
             count += 1
-            yield Point(LatLon(lat, lon))
+            yield Point(LatLon(lat, lon), weight)
         logging.info('read %d points' % count)
 
 

--- a/heatmap.py
+++ b/heatmap.py
@@ -846,9 +846,8 @@ class CSVFileReader(FileReader):
         count = 0
         for row in reader:
             (lat, lon) = (float(row[0]), float(row[1]))
-            weight = float(row[2]) if len(row) > 2 else 1.0
             count += 1
-            yield Point(LatLon(lat, lon), weight)
+            yield Point(LatLon(lat, lon))
         logging.info('read %d points' % count)
 
 


### PR DESCRIPTION
Two edits:
One avoids the ZeroDivisionError by defaulting to the base value of the colormap.
The other reacts to IndexError by clamping the return value in ColorMap.get()
