### PR TITLE
Add support for Python 3.7, remove EOL 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ python:
     - "2.7_with_system_site_packages"
     - "3.6"
     - "3.5"
-    - "3.4"
-    - "3.4_with_system_site_packages"
 
 before_install:
     - sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.7/lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ python:
     - "3.6"
     - "3.5"
 
+# Enable 3.7 without globally enabling dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+
 before_install:
     - sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.7/lib/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 
 install:
     - pip install -U pip
+    - pip install -U pyopenssl
     - pip install coverage
     - travis_retry pip install coveralls
     - travis_retry pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
     - sudo ln -s /usr/lib/`uname -i`-linux-gnu/libz.so ~/virtualenv/python2.7/lib/
 
 install:
+    - pip install -U pip
     - pip install coverage
     - travis_retry pip install coveralls
     - travis_retry pip install -r requirements.txt


### PR DESCRIPTION
Add support for Python 3.7, which needs Xenial on Travis CI (https://github.com/travis-ci/travis-ci/issues/9815).

Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history